### PR TITLE
Change separator

### DIFF
--- a/product-translator/README.md
+++ b/product-translator/README.md
@@ -11,7 +11,7 @@ The translation can be divided into two processes, which are executed asynchrono
 - Variants Translation
 
 ## Product Translation
-The translator concatenates the following product fields into a single-line text with separator '|':
+The translator concatenates the following product fields into a single-line text with separator '[#]':
 1. Product Name
 2. Product Description
 3. Meta Description

--- a/product-translator/src/mappers/products.mapper.js
+++ b/product-translator/src/mappers/products.mapper.js
@@ -20,7 +20,7 @@ const transformProductToString = (product, language) => {
   localizedFields[TRANSLATION_FIELD_POS.META_KEYWORDS] = productMetaKeywords;
   localizedFields[TRANSLATION_FIELD_POS.META_TITLE] = productMetaTitle;
 
-  return localizedFields.join("|");
+  return localizedFields.join("[#]");
 };
 
 const transformProductAttributeToString = (variantAttributeValue, language) => {

--- a/product-translator/src/utils/actions.utils.js
+++ b/product-translator/src/utils/actions.utils.js
@@ -8,7 +8,7 @@ function getUpdatedLocalizedString(languagesInProject, translationResult, pos) {
     const languageName = getLanguageName(language);
     const translatedString = translationResult?.[languageName];
     if (translatedString) {
-      const translatedProductName = translatedString.split("|")[pos];
+      const translatedProductName = translatedString.split("[#]")[pos];
       value[language] = translatedProductName;
     }
   }


### PR DESCRIPTION
Replace the old separator `|` by `[#]`. It is because the separator may be removed from translation result by OpenAI platform for unknown reason, which causes the field position incorrect when updating the translation result to Composable Commerce.